### PR TITLE
feat(ngrx-ducks): add duckReducerFrom()

### DIFF
--- a/ngrx/ducks/src/lib/reducer/reducer-from.ts
+++ b/ngrx/ducks/src/lib/reducer/reducer-from.ts
@@ -35,3 +35,9 @@ export function reducerFrom<T extends new () => InstanceType<T>>(
       : state;
   };
 }
+
+export function duckReducerFrom<T extends new () => InstanceType<T>>(
+  Token: T
+) {
+  return (state, action) => reducerFrom(Token)(state, action);
+}


### PR DESCRIPTION
By using **duckReducerFrom** there is no need to create an additional *reducer* method for every `Duck`. It can be used like this:

```typescript
StoreModule.forFeature('counter', duckReducerFrom(Counter))
```